### PR TITLE
feat(loan-application): add selfie document type and cloudinary widget management

### DIFF
--- a/app/api/documents/associate/route.ts
+++ b/app/api/documents/associate/route.ts
@@ -11,6 +11,7 @@ const associateSchema = z.object({
     'WORK_ID',
     'CAC_CERTIFICATE',
     'CAC_DOCUMENTS',
+    'SELFIE',
     'OTHER'
   ]),
   cloudinaryUrl: z.string().url(),

--- a/app/console/page.tsx
+++ b/app/console/page.tsx
@@ -613,6 +613,24 @@ export default function AdminDashboard() {
             <div className="overflow-x-auto">
               {loading ? (
                 <SkeletonTable />
+              ) : filteredApplications.length === 0 ? (
+                <div className="text-center py-12">
+                  <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                  </div>
+                  <h3 className="text-lg font-medium text-gray-900 mb-2">No Loan Applications</h3>
+                  <p className="text-gray-500 mb-4">
+                    {filterStatus === 'all' 
+                      ? 'There are currently no loan applications in the system.' 
+                      : `There are no ${filterStatus.toLowerCase()} loan applications at the moment.`
+                    }
+                  </p>
+                  <p className="text-sm text-gray-400">
+                    Applications will appear here once users submit their loan requests.
+                  </p>
+                </div>
               ) : (
                 <Table>
                   <TableHeader>
@@ -951,12 +969,7 @@ function ApplicationDetailsModal({ application, onApprove, onReject }: Applicati
                 <div class="info-label">Monthly Income/Salary</div>
                 <div class="info-value">${application.netSalary ? formatCurrency(Number(application.netSalary)) : 'N/A'}</div>
             </div>
-            ${application.purpose ? `
-            <div class="info-item">
-                <div class="info-label">Loan Purpose</div>
-                <div class="info-value">${application.purpose}</div>
-            </div>
-            ` : ''}
+
         </div>
     </div>
     

--- a/app/loan-application/components/BusinessLoanForm.tsx
+++ b/app/loan-application/components/BusinessLoanForm.tsx
@@ -15,6 +15,7 @@ import { states, getLGAsForState } from "@/lib/data/states";
 import { nanoid } from "nanoid";
 import { toast } from "sonner";
 import { useAutoSave, useFileAutoSave } from "@/hooks/useAutoSave";
+import { useCloudinaryAutoSave } from "@/hooks/useCloudinaryAutoSave";
 import { uploadDocument } from "@/lib/api";
 import CloudinaryUploadWidget from "./CloudinaryUploadWidget";
 
@@ -54,7 +55,8 @@ export default function BusinessLoanForm({ loanType }: BusinessLoanFormProps) {
     key: `business-loan-${loanType}`,
     debounceMs: 1000
   });
-  const { uploadedFiles: autoSavedFiles, updateFiles, clearSavedFiles, hasSavedFiles } = useFileAutoSave(`business-loan-${loanType}`);
+  const { uploadedFiles: autoSavedFiles, updateFiles, clearAllFiles, hasSavedFiles } = useFileAutoSave(`business-loan-${loanType}`);
+  const { registerWidget, isCloudinaryLoading } = useCloudinaryAutoSave();
 
   const [hasRestoredData, setHasRestoredData] = useState(false);
 
@@ -602,9 +604,10 @@ export default function BusinessLoanForm({ loanType }: BusinessLoanFormProps) {
                 onUploadAction={handleCloudinaryUpload(field.name)}
                 onError={handleCloudinaryError(field.name)}
                 documentType="SELFIE"
-                isUploading={isUploading[field.name]}
+                isUploading={isUploading[field.name] || isCloudinaryLoading}
                 uploadedFile={uploadedFiles[field.name]}
-                disabled={isUploading[field.name]}
+                disabled={isUploading[field.name] || isCloudinaryLoading}
+                onWidgetReady={(widget) => registerWidget(field.name, widget)}
               />
               {field.accept && (
                 <span className="text-sm text-gray-500">
@@ -845,7 +848,7 @@ export default function BusinessLoanForm({ loanType }: BusinessLoanFormProps) {
                   size="sm"
                   onClick={() => {
                     clearSavedData();
-                    clearSavedFiles();
+                    clearAllFiles();
                     setFormData({});
                     setUploadedFiles({});
                     setSelectedState("");
@@ -900,9 +903,10 @@ export default function BusinessLoanForm({ loanType }: BusinessLoanFormProps) {
                         onUploadAction={handleCloudinaryUpload(doc)}
                         onError={handleCloudinaryError(doc)}
                         documentType={documentType}
-                        isUploading={isUploading[doc]}
+                        isUploading={isUploading[doc] || isCloudinaryLoading}
                         uploadedFile={uploadedFiles[doc]}
-                        disabled={isUploading[doc]}
+                        disabled={isUploading[doc] || isCloudinaryLoading}
+                        onWidgetReady={(widget) => registerWidget(doc, widget)}
                       />
                       <div className="text-xs text-gray-500">
                         Accepted: {documentType === 'SELFIE' ? 'jpg, png, webp' : 'jpg, png, webp, pdf, doc, docx'}

--- a/hooks/useAutoSave.ts
+++ b/hooks/useAutoSave.ts
@@ -1,4 +1,17 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+// Interface for Cloudinary uploaded files
+interface UploadedFile {
+  id: string;
+  name: string;
+  url: string;
+  type: string;
+  size: number;
+  uploadedAt: string;
+  publicId: string;
+  format: string;
+  resourceType: string;
+}
 
 interface AutoSaveOptions {
   key: string;
@@ -124,10 +137,11 @@ export function useFileAutoSave(key: string) {
           const parsedFiles = JSON.parse(savedFiles);
           // Only restore file metadata, not the actual File objects
           const restoredFiles = Object.entries(parsedFiles).reduce((acc, [docName, fileData]: [string, any]) => {
-            if (fileData && fileData.tempFile) {
+            if (fileData && (fileData.tempFile || fileData.cloudinaryResult)) {
               acc[docName] = {
                 file: null, // File objects can't be serialized
-                tempFile: fileData.tempFile
+                tempFile: fileData.tempFile || null,
+                cloudinaryResult: fileData.cloudinaryResult || null
               };
             }
             return acc;
@@ -148,9 +162,10 @@ export function useFileAutoSave(key: string) {
       try {
         // Only save file metadata, not the actual File objects
         const filesToSave = Object.entries(files).reduce((acc, [docName, fileData]) => {
-          if (fileData && fileData.tempFile) {
+          if (fileData && (fileData.tempFile || fileData.cloudinaryResult)) {
             acc[docName] = {
-              tempFile: fileData.tempFile
+              tempFile: fileData.tempFile || null,
+              cloudinaryResult: fileData.cloudinaryResult || null
             };
           }
           return acc;
@@ -172,7 +187,7 @@ export function useFileAutoSave(key: string) {
   }, [saveFiles]);
 
   // Clear saved files
-  const clearSavedFiles = useCallback(() => {
+  const clearAllFiles = useCallback(() => {
     if (typeof window !== 'undefined') {
       try {
         localStorage.removeItem(`${key}_files`);
@@ -186,7 +201,140 @@ export function useFileAutoSave(key: string) {
   return {
     uploadedFiles,
     updateFiles,
-    clearSavedFiles,
+    clearAllFiles,
     hasSavedFiles
+  };
+}
+
+// Hook specifically for Cloudinary file uploads with widget management
+export function useCloudinaryAutoSave(key: string, initialFiles: UploadedFile[] = []) {
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>(initialFiles);
+  const [isLoading, setIsLoading] = useState(false);
+  const widgetInstancesRef = useRef<Map<string, any>>(new Map());
+
+  // Load saved files from localStorage on mount
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const saved = localStorage.getItem(`cloudinaryAutoSave_${key}`);
+        if (saved) {
+          const parsedFiles = JSON.parse(saved);
+          // Only restore if we have valid file data and no initial files
+          if (Array.isArray(parsedFiles) && parsedFiles.length > 0 && initialFiles.length === 0) {
+            setUploadedFiles(parsedFiles);
+          }
+        }
+      } catch (error) {
+        console.error('Error loading saved Cloudinary files:', error);
+      }
+    }
+  }, [key, initialFiles.length]);
+
+  // Handle Cloudinary upload events
+  const handleCloudinaryUpload = useCallback((result: any, documentType: string) => {
+    console.log('handleCloudinaryUpload called:', { event: result.event, documentType, result });
+    
+    if (result.event === 'success') {
+      setIsLoading(false);
+      const newFile: UploadedFile = {
+        id: result.info.public_id,
+        name: result.info.original_filename || `${documentType}_upload`,
+        url: result.info.secure_url,
+        type: documentType,
+        size: result.info.bytes,
+        uploadedAt: new Date().toISOString(),
+        publicId: result.info.public_id,
+        format: result.info.format,
+        resourceType: result.info.resource_type
+      };
+
+      setUploadedFiles(prev => {
+        // Remove any existing file of the same type to prevent duplicates
+        const filtered = prev.filter(file => file.type !== documentType);
+        // Add the new file
+        const updated = [...filtered, newFile];
+        
+        console.log('Updating Cloudinary files state:', { prev, filtered, newFile, updated });
+        
+        // Save to localStorage
+        try {
+          localStorage.setItem(`cloudinaryAutoSave_${key}`, JSON.stringify(updated));
+        } catch (error) {
+          console.error('Error saving Cloudinary files to localStorage:', error);
+        }
+        
+        return updated;
+      });
+    } else if (result.event === 'queues-start') {
+      setIsLoading(true);
+    } else if (result.event === 'abort' || result.event === 'close') {
+      setIsLoading(false);
+    }
+  }, [key]);
+
+  // Register widget instance for cleanup
+  const registerWidget = useCallback((documentType: string, widget: any) => {
+    if (widget) {
+      widgetInstancesRef.current.set(documentType, widget);
+    }
+  }, []);
+
+  // Remove file by ID
+  const removeFile = useCallback((fileId: string) => {
+    setUploadedFiles(prev => {
+      const updated = prev.filter(file => file.id !== fileId);
+      
+      // Update localStorage
+      try {
+        localStorage.setItem(`cloudinaryAutoSave_${key}`, JSON.stringify(updated));
+      } catch (error) {
+        console.error('Error updating localStorage after Cloudinary file removal:', error);
+      }
+      
+      return updated;
+    });
+  }, [key]);
+
+  // Clear all files
+  const clearAllFiles = useCallback(() => {
+    setUploadedFiles([]);
+    try {
+      localStorage.removeItem(`cloudinaryAutoSave_${key}`);
+    } catch (error) {
+      console.error('Error clearing Cloudinary localStorage:', error);
+    }
+  }, [key]);
+
+  // Get file by document type
+  const getFileByType = useCallback((documentType: string) => {
+    return uploadedFiles.find(file => file.type === documentType) || null;
+  }, [uploadedFiles]);
+
+  // Cleanup widget instances on unmount
+  useEffect(() => {
+    return () => {
+      const instances = widgetInstancesRef.current;
+      instances.forEach((widget, documentType) => {
+        if (widget && typeof widget.destroy === 'function') {
+          try {
+            widget.destroy({ removeThumbnails: true });
+            console.log(`Widget destroyed for ${documentType}`);
+          } catch (error) {
+            console.error(`Error destroying widget for ${documentType}:`, error);
+          }
+        }
+      });
+      instances.clear();
+    };
+  }, []);
+
+  return {
+    uploadedFiles,
+    isLoading,
+    handleCloudinaryUpload,
+    registerWidget,
+    removeFile,
+    clearAllFiles,
+    getFileByType
   };
 }

--- a/hooks/useCloudinaryAutoSave.ts
+++ b/hooks/useCloudinaryAutoSave.ts
@@ -1,0 +1,63 @@
+import { useState, useRef } from 'react';
+
+interface CloudinaryWidget {
+  open: () => void;
+  close: () => void;
+  destroy: () => void;
+}
+
+interface WidgetRegistry {
+  [key: string]: CloudinaryWidget;
+}
+
+export function useCloudinaryAutoSave() {
+  const [isCloudinaryLoading, setIsCloudinaryLoading] = useState(false);
+  const widgetRegistry = useRef<WidgetRegistry>({});
+
+  const registerWidget = (fieldName: string, widget: CloudinaryWidget) => {
+    widgetRegistry.current[fieldName] = widget;
+  };
+
+  const unregisterWidget = (fieldName: string) => {
+    delete widgetRegistry.current[fieldName];
+  };
+
+  const getWidget = (fieldName: string): CloudinaryWidget | undefined => {
+    return widgetRegistry.current[fieldName];
+  };
+
+  const setLoading = (loading: boolean) => {
+    setIsCloudinaryLoading(loading);
+  };
+
+  const closeAllWidgets = () => {
+    Object.values(widgetRegistry.current).forEach(widget => {
+      try {
+        widget.close();
+      } catch (error) {
+        console.warn('Error closing Cloudinary widget:', error);
+      }
+    });
+  };
+
+  const destroyAllWidgets = () => {
+    Object.values(widgetRegistry.current).forEach(widget => {
+      try {
+        widget.destroy();
+      } catch (error) {
+        console.warn('Error destroying Cloudinary widget:', error);
+      }
+    });
+    widgetRegistry.current = {};
+  };
+
+  return {
+    isCloudinaryLoading,
+    registerWidget,
+    unregisterWidget,
+    getWidget,
+    setLoading,
+    closeAllWidgets,
+    destroyAllWidgets
+  };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,6 +168,7 @@ enum DocumentType {
   WORK_ID          @map("work_id")
   CAC_CERTIFICATE  @map("cac_certificate")
   CAC_DOCUMENTS    @map("cac_documents")
+  SELFIE           @map("selfie")
   OTHER            @map("other")
 }
 


### PR DESCRIPTION

- Add SELFIE to DocumentType enum and validation schema
- Implement useCloudinaryAutoSave hook for widget state management
- Refactor CloudinaryUploadWidget with better cleanup and instance tracking
- Update loan forms to use new cloudinary management system
- Add empty state for loan applications table