### PR TITLE
fix(storage): handle full Cloudinary URLs in getSignedUrl

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -476,9 +476,9 @@ export default function Dashboard() {
               </CardHeader>
               <CardContent>
                 <div className="text-center py-12">
-                  <div className="mx-auto w-16 h-16 mb-4 text-gray-400">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-full h-full">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c0 .621-.504 1.125-1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                  <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <svg className="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
                   </div>
                   <h3 className="text-lg font-semibold text-gray-900 mb-2">No Loan Applications</h3>

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -174,6 +174,12 @@ export async function getSignedUrl(
     console.log(`Generating signed URL for file: ${filePath}`)
     
     if (hasCloudinaryConfig) {
+      // Check if filePath is already a full Cloudinary URL
+      if (filePath.startsWith('https://res.cloudinary.com/')) {
+        console.log(`File path is already a full Cloudinary URL: ${filePath}`)
+        return filePath
+      }
+      
       // For Cloudinary, files are already publicly accessible
       // We can generate a signed URL if needed, but for now return the public URL
       // Extract public ID from file path


### PR DESCRIPTION
refactor(dashboard): update empty state UI for loan applications
perf(documents): stream Cloudinary downloads instead of redirecting

Improve Cloudinary URL handling by checking for existing full URLs. Redesign empty state UI with better visual hierarchy. Optimize document downloads by streaming files directly instead of redirecting to Cloudinary URLs.